### PR TITLE
Flesh out some of the protocol details

### DIFF
--- a/draft-wang-ppm-dap-taskprov.md
+++ b/draft-wang-ppm-dap-taskprov.md
@@ -404,7 +404,7 @@ then aggregation of reports will fail. This is guaranteed by the binding of
 report metadata to encrypted input shares provided by HPKE encryption.
 
 > OPEN ISSUE: What if the Collector and Aggregators don't agree on the task
-> configuration? Consider adding
+> configuration? Decryption should fail.
 
 A "task" now means the same task ID and same task configuration, if a malicious
 client changes the task ID or task configuration, its report will be aggregated

--- a/draft-wang-ppm-dap-taskprov.md
+++ b/draft-wang-ppm-dap-taskprov.md
@@ -83,9 +83,9 @@ Client-Aggregator, Collector-Aggregator, and Aggregator-Aggregator
 relationships. These include:
 
 * The Collector's HPKE {{?RFC9180}} configuration used by the Aggregators to
-  encrypt aggregate shares
+  encrypt aggregate shares.
 
-* Any assets required for authenticating HTTP requests
+* Any assets required for authenticating HTTP requests.
 
 This specification does not specify a mechanism for provisioning these assets;
 as in the core DAP protocol, these are presumed to be configured out-of-band.
@@ -372,7 +372,7 @@ Next, the Helper decides whether to opt in to the task as described in
 > OPEN ISSUE: In case of opt-out, would it be useful to specify how to report
 > this to the Author?
 
-Finally, the Helper completes the upload request as usual, deriving the VDAF
+Finally, the Helper completes the aggregate initialize request as usual, deriving the VDAF
 verification key for the task as described in {{vdaf-verify-key}}.
 
 # Collector Behavior

--- a/draft-wang-ppm-dap-taskprov.md
+++ b/draft-wang-ppm-dap-taskprov.md
@@ -351,18 +351,18 @@ to the same task. In particular, it checks that:
 1. Either all report shares have the `task_prov` extension or none do. If not
    the Helper MUST abort with "unrecognizedMessage".
 
-1. All report shares with the `task_prov` extension have the same payload. If
+1. All report shares with the `task_prov` extension have the same extension payload. If
    not, the Helper MUST abort with "unrecognizedMessage".
 
 > OPEN ISSUE: This awkward input validation step could be skipped if
 > `AggregateInitializeReq` had an extension field that we could stick the task
 > configuration in. This would also save significantly in overhead.
 
-Next, the Helper attempts to parse the extension paylaod. If parsing fails, it
+Next, the Helper attempts to parse the extension payload. If parsing fails, it
 MUST abort with "unrecognizedMessage".
 
 Next, the Helper checks that the task ID included in the message matches the
-task ID derived from the extension payload ad defined in {{construct-task-id}}.
+task ID derived from the extension payload as defined in {{construct-task-id}}.
 If not, the Helper MUST abort with "unrecognizedTask".
 
 Next, the Helper decides whether to opt in to the task as described in

--- a/draft-wang-ppm-dap-taskprov.md
+++ b/draft-wang-ppm-dap-taskprov.md
@@ -167,9 +167,9 @@ selection. It is defined as follows:
 
 ~~~
 struct {
-    QueryType query_type;      /* Defined in I-D.draft-ietf-ppm-dap-02 */
-    Duration time_precision;   /* Defined in I-D.draft-ietf-ppm-dap-02 */
-    uint16 max_batch_lifetime; /* Defined in I-D.draft-ietf-ppm-dap-02 */
+    QueryType query_type;         /* Defined in I-D.draft-ietf-ppm-dap-02 */
+    Duration time_precision;      /* Defined in I-D.draft-ietf-ppm-dap-02 */
+    uint16 max_batch_query_count; /* Defined in I-D.draft-ietf-ppm-dap-02 */
     uint32 min_batch_size;
     select (QueryConfig.query_type) {
         case time-interval: Empty;


### PR DESCRIPTION
- Clean up the introduction. Be sure to mention all the salient points, including that some artifacts are still negotiated out of batnd.

- Spell out "opt-in" versus "opt-out" conditions. This makes the previous {{provisioning-a-task}} section more explicit and adds some additional features.

- Formalize the language in the protocol behavior sections.

- Add notes and an attack to security considerations.

- Move max_bach_lifetime into QueryConfig, as this parameter constrains queries.

- Various editorial things, including aligning with editorial changes in DAP-02.