### PR TITLE
Use "dap-taskprov" for the salt constant

### DIFF
--- a/draft-wang-ppm-dap-taskprov.md
+++ b/draft-wang-ppm-dap-taskprov.md
@@ -237,7 +237,7 @@ task_id = HKDF-Extract(task_prov_salt, task_config)
 
 where `task_config` is the `TaskConfig` structure disseminated by the Author.
 String `task_prov_salt` is defined to be the SHA-256 hash of the octet string
-"dap-taskprov-00". Function HKDF-Extract() denotes the HKDF extraction function
+"dap-taskprov". Function HKDF-Extract() denotes the HKDF extraction function
 defined in {{!RFC5869}} instantiated with SHA-256.
 
 ## Deriving the VDAF Verification Key {#vdaf-verify-key}


### PR DESCRIPTION
We use "dap-taskprov-00" right now, the idea being that we would revise this to "dap-taskprov-01" for the next draft. Shan suggests this might end up being a footgun when we have to update to the next draft.