### PR TITLE
Editorial changes

### DIFF
--- a/draft-wang-ppm-dap-taskprov.md
+++ b/draft-wang-ppm-dap-taskprov.md
@@ -480,9 +480,9 @@ MUST abort with "unrecognizedTask". The Client will then retry with the task
 advertisement.
 
 If the Client advertises the task, the Leader checks that the task ID indicated
-by the upload request matches the task ID derived from the extension payload as
-specified in {{definition}}. If the task ID does not match, then the Leader MUST
-abort with "unrecognizedTask".
+by the upload request matches the task ID derived from the "dap-taskprov" HTTP
+header as specified in {{definition}}. If the task ID does not match, then the
+Leader MUST abort with "unrecognizedTask".
 
 The Leader then decides whether to opt in to the task as described in
 {{provisioning-a-task}}. If it opts out, it MUST abort the upload request with

--- a/draft-wang-ppm-dap-taskprov.md
+++ b/draft-wang-ppm-dap-taskprov.md
@@ -566,7 +566,7 @@ of time.
 
 The Taskbind extension has the same security and privacy considerations as the
 core DAP protocol. In addition, successful execution of a DAP task implies
-agreement on the task configuration. This is providing by binding the
+agreement on the task configuration. This is provided by binding the
 parameters to the task ID, which in turn is bound to each report uploaded for a
 task. Furthermore, inclusion of the Taskbind extension in the report share
 means Aggregators that do not implement this extension will reject the report
@@ -596,7 +596,7 @@ attempt to pollute an Aggregator's long-term storage by uploading reports for
 many (thousands or perhaps millions) of distinct tasks. While this does not
 directly impact tasks used by honest Clients, it does present a
 Denial-of-Service risk for the Aggregators themselves. This can be mitigated by
-limiting the rate at which new tasks or configured. In addition, deployments
+limiting the rate at which new tasks are configured. In addition, deployments
 SHOULD arrange for the Author to digitally sign the task configuration so that
 Clients cannot forge task creation.
 

--- a/draft-wang-ppm-dap-taskprov.md
+++ b/draft-wang-ppm-dap-taskprov.md
@@ -314,8 +314,8 @@ performed completely in-band, via HTTP request headers.
 
 This method presumes the existence of a logical "task author" (written as
 "Author" hereafter) who is capable of pushing configurations to Clients. All
-parameters required by downstream entities (the Aggregators and Collector) are
-carried by HTTP headers piggy-backed on the protocol flow.
+parameters required by downstream entities (the Aggregators) are carried by HTTP
+headers piggy-backed on the protocol flow.
 
 This mechanism is designed with the same security and privacy considerations of
 the core DAP protocol. The Author is not regarded as a trusted third party: it

--- a/draft-wang-ppm-dap-taskprov.md
+++ b/draft-wang-ppm-dap-taskprov.md
@@ -530,8 +530,8 @@ proceeds as follows.
 First, the Helper attempts to parse payload of the "dap-taskprov" HTTP header.
 If this step fails, the Helper MUST abort with "invalidMessage".
 
-Next, the Helper checks that the task ID indicated in the upload request matches
-the task ID derived from the `TaskConfig` as defined in {{definition}}.
+Next, the Helper checks that the task ID indicated in the aggregation request
+matches the task ID derived from the `TaskConfig` as defined in {{definition}}.
 If not, the Helper MUST abort with "unrecognizedTask".
 
 Next, the Helper decides whether to opt in to the task as described in
@@ -551,7 +551,7 @@ payload, the Helper MUST mark the report as invalid with error
 
 Upon receiving a `TaskConfig` from the Author, the Collector first decides
 whether to opt into the task as described in {{provisioning-a-task}}. If the
-Collector opts out, it MUST NOT attempt to upload reports for the task.
+Collector opts out, it MUST NOT attempt to issue collect requests for the task.
 
 Otherwise, once opted in, the Collector MAY begin to issue collect requests for
 the task. The task ID for each request MUST be derived from the `TaskConfig` as


### PR DESCRIPTION
This makes a few editorial fixes throughout the document.

- There's one reference to the payload of the extension left over from past drafts (the payload should now be empty).
- There are contradicting statements that the collector receives task parameters via HTTP headers and directly from the task author. I removed mention of HTTP headers, since the collector only initiates HTTP requests.
- I changed places where mention was made of the collector making an upload request or the helper receiving an upload request.